### PR TITLE
Validate agent configuration percentages

### DIFF
--- a/dejavas-backend/main.py
+++ b/dejavas-backend/main.py
@@ -1,6 +1,6 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
-from typing import List, Optional
+from typing import List
 import uuid
 import random
 
@@ -50,7 +50,19 @@ def upload_brief(brief: Brief):
 @app.post("/configure-agents/{session_id}")
 def configure_agents(session_id: str, config: AgentConfig):
     if session_id not in simulations:
-        return {"error": "Session not found"}
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    total = (
+        config.customer_percentage
+        + config.competitor_percentage
+        + config.influencer_percentage
+        + config.internal_team_percentage
+    )
+    if total != 100:
+        raise HTTPException(
+            status_code=400, detail="Agent percentages must sum to 100"
+        )
+
     simulations[session_id]["agent_config"] = config
     return {"message": "Agent configuration saved"}
 

--- a/dejavas-backend/tests/test_agent_config.py
+++ b/dejavas-backend/tests/test_agent_config.py
@@ -1,0 +1,42 @@
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+
+def test_configure_agents_valid_percentages():
+    brief_payload = {
+        "product_name": "Test",
+        "features": [{"title": "F1", "description": "D1"}],
+    }
+    upload_resp = client.post("/upload-brief/", json=brief_payload)
+    session_id = upload_resp.json()["session_id"]
+
+    config_payload = {
+        "customer_percentage": 25,
+        "competitor_percentage": 25,
+        "influencer_percentage": 25,
+        "internal_team_percentage": 25,
+    }
+    resp = client.post(f"/configure-agents/{session_id}", json=config_payload)
+    assert resp.status_code == 200
+    assert resp.json() == {"message": "Agent configuration saved"}
+
+
+def test_configure_agents_invalid_percentages():
+    brief_payload = {
+        "product_name": "Test",
+        "features": [{"title": "F1", "description": "D1"}],
+    }
+    upload_resp = client.post("/upload-brief/", json=brief_payload)
+    session_id = upload_resp.json()["session_id"]
+
+    config_payload = {
+        "customer_percentage": 30,
+        "competitor_percentage": 30,
+        "influencer_percentage": 30,
+        "internal_team_percentage": 30,
+    }
+    resp = client.post(f"/configure-agents/{session_id}", json=config_payload)
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Agent percentages must sum to 100"


### PR DESCRIPTION
## Summary
- enforce agent percentage totals to equal 100 using HTTPException
- add tests covering valid and invalid agent configurations
- remove unused Optional import

## Testing
- `pytest tests/test_agent_config.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install fastapi pydantic uvicorn` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6895a307a888832cb3a7d67b14230f1e